### PR TITLE
mellow down the initial required field errors (bug 910009)

### DIFF
--- a/src/media/css/forms.styl
+++ b/src/media/css/forms.styl
@@ -88,6 +88,11 @@ textarea {
     &:invalid {
         border-color: $angry-cvan-red;
     }
+    &:invalid[value] + .hint {
+        /* Highlight the hint if a value is input, but is invalid. */
+        color: lighten($angry-cvan-red, 10%);
+        font-style: italic;
+    }
 }
 label p[reason] {
     color: $angry-cvan-red;
@@ -97,6 +102,17 @@ label p[reason] {
 label :required:invalid:not([value]) ~ [reason=required],
 label [value]:invalid ~ [reason=invalid] {
     display: block;
+}
+.required:after {
+    color: $angry-cvan-red;
+    content: '*';
+    left: 3px;
+    position: relative;
+}
+.hint {
+    color: $london-fog-gray;
+    font-size: 11px;
+    margin-top: 2px;
 }
 
 .pretty-select,

--- a/src/templates/new_collection.html
+++ b/src/templates/new_collection.html
@@ -5,33 +5,30 @@
   <input type="hidden" name="collection_type" value="{{ type }}">
 
   <label>
-    {{ _('Name') }}
+    <span class="required">{{ _('Name') }}</span>
     <input type="text" name="name" required>
     {% if type == 1 %}
-      <p>{{ _('The name is not shown to users, it is only for convenience.') }}</p>
+      <p class="hint">{{ _('The name is not shown to users, it is only for convenience.') }}</p>
     {% endif %}
-    <p reason="required">{{ _('A name is required') }}</p>
   </label>
 
   <label>
-    {{ _('Collection Slug') }}
+    <span class="required">{{ _('Collection Slug') }}</span>
     <input type="text" name="slug" required pattern="[a-zA-Z][\w\-]*" maxlength="30">
-    <p reason="required">{{ _('A slug is required') }}</p>
-    <p reason="invalid">{{ _('Slugs must start with a letter and can only contain letters, numbers, and hyphens. It must be 30 characters or less.') }}</p>
+    <p class="hint">{{ _('Slugs must start with a letter and can only contain letters, numbers, and hyphens. It must be 30 characters or less.') }}</p>
   </label>
 
   {# Only curated collections get authors #}
   {% if type == 0 %}
     <label>
-      {{ _('Author Name') }}
+      <span class="required">{{ _('Author Name') }}</span>
       <input type="text" name="author">
     </label>
   {% endif %}
 
   <label>
-    {{ _('Description') }}
+    <span class="required">{{ _('Description') }}</span>
     <textarea name="description" required></textarea>
-    <p reason="required">{{ _('A description is required') }}</p>
   </label>
 
   <div class="row gutter">
@@ -66,14 +63,14 @@
   {% if type == 0 %}
   <div class="row gutter">
     <label class="half">
-      {{ _('Background Color') }}
+      <span class="required">{{ _('Background Color') }}</span>
       <input type="color" name="background_color" required pattern="{{ COLOR_PATTERN }}" value="#FFFFFF">
       <p reason="required">{{ _('A background color is required') }}</p>
       <p reason="invalid">{{ _('Please enter a hex color (e.g.: "#AB78EF")') }}</p>
     </label>
 
     <label class="half">
-      {{ _('Text Color') }}
+      <span class="required">{{ _('Text Color') }}</span>
       <input type="color" name="text_color" required pattern="{{ COLOR_PATTERN }}" value="#B2B2B2">
       <p reason="required">{{ _('A text color is required') }}</p>
       <p reason="invalid">{{ _('Please enter a hex color (e.g.: "#AB78EF")') }}</p>


### PR DESCRIPTION
**Replaced the validation error notices with a little red star to indicate `required`. The borders are still red.**

![screen shot 2013-09-12 at 4 00 19 pm](https://f.cloud.github.com/assets/674727/1134918/20558dca-1bff-11e3-973b-80be9f95b201.png)

**Invalid inputs with hints highlight the hints red**

![screen shot 2013-09-12 at 4 00 40 pm](https://f.cloud.github.com/assets/674727/1134920/2ef35bf0-1bff-11e3-958d-b64b8e4f1632.png)
